### PR TITLE
Summand Index Functions

### DIFF
--- a/compdata.cabal
+++ b/compdata.cabal
@@ -167,6 +167,7 @@ library
                         Data.Comp.Multi.Projection
                         Data.Comp.Multi.LowerOrder
                         Data.Comp.Multi.Multi.Projection
+                        Data.Comp.Multi.SummandIndex
 
   Other-Modules:        Data.Comp.SubsumeCommon
                         Data.Comp.Derive.Equality

--- a/src/Data/Comp/Multi.hs
+++ b/src/Data/Comp/Multi.hs
@@ -22,6 +22,7 @@ module Data.Comp.Multi (
   , module Data.Comp.Multi.Annotation
   , module Data.Comp.Multi.Equality
   , module Data.Comp.Multi.Generic
+  , module Data.Comp.Multi.SummandIndex
     ) where
 
 import Data.Comp.Multi.Algebra
@@ -31,6 +32,7 @@ import Data.Comp.Multi.Generic
 import Data.Comp.Multi.HFunctor
 import Data.Comp.Multi.Sum
 import Data.Comp.Multi.Term
+import Data.Comp.Multi.SummandIndex
 
 {- $ex1
 The example illustrates how to use generalised compositional data types

--- a/src/Data/Comp/Multi/SummandIndex.hs
+++ b/src/Data/Comp/Multi/SummandIndex.hs
@@ -1,0 +1,34 @@
+module Data.Comp.Multi.SummandIndex where
+
+import Data.Comp.SubsumeCommon
+
+
+type family SummandSize f where
+  SummandSize (f :+: g) = SummandSize f + SummandSize g
+  SummandSize _ = 1
+
+
+summandSize :: (Integral num) => (Proxy f) -> num
+summandSize pr = fromIntegral $ natVal (P :: Proxy (SummandSize f))
+
+
+class SummandIndex p f g where
+    summandIndex :: Proxy p -> f -> Int
+
+
+instance SummandIndex (Found Here) f f where
+    summandIndex _ _ = 0
+
+
+instance SummandIndex (Found p) f g => SummandIndex (Found (Le p)) f (g :+: g') where
+    summandIndex _ x = summandIndex (P :: Proxy (Found p)) x
+
+
+instance SummandIndex (Found p) f g => SummandIndex (Found (Ri p)) f (g' :+: g) where
+    summandIndex _ x = summandSize (P :: Proxy g) + summandIndex (P :: Proxy (Found p)) x
+
+
+instance (SummandIndex (Found p1) f1 g, SummandIndex (Found p2) f2 g)
+    => SummandIndex (Found (Sum p1 p2)) (f1 :+: f2) g where
+    summandIndex _ (Inl x) = summandIndex (P :: Proxy (Found p1)) x
+    summandIndex _ (Inr x) = summandIndex (P :: Proxy (Found p2)) x

--- a/src/Data/Comp/Multi/SummandIndex.hs
+++ b/src/Data/Comp/Multi/SummandIndex.hs
@@ -1,34 +1,45 @@
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Data.Comp.Multi.SummandIndex where
 
+import Data.Kind
+import Data.Comp.Multi.Ops
 import Data.Comp.SubsumeCommon
+import GHC.TypeLits
 
 
-type family SummandSize f where
+type family SummandSize (f :: (Type -> Type) -> Type -> Type) where
   SummandSize (f :+: g) = SummandSize f + SummandSize g
   SummandSize _ = 1
 
 
-summandSize :: (Integral num) => (Proxy f) -> num
-summandSize pr = fromIntegral $ natVal (P :: Proxy (SummandSize f))
+summandSize :: forall (f :: (Type -> Type) -> Type -> Type) (num :: Type) . (Integral num, KnownNat (SummandSize f)) => (Proxy f) -> num
+summandSize (pr :: Proxy f) = fromIntegral $ natVal (P :: Proxy (SummandSize f))
 
 
-class SummandIndex p f g where
-    summandIndex :: Proxy p -> f -> Int
+class SummandIndex p (f :: (Type -> Type) -> Type -> Type) (g :: (Type -> Type) -> Type -> Type) where
+    summandIndex :: Proxy g -> Proxy p -> f a i -> Int
 
 
 instance SummandIndex (Found Here) f f where
-    summandIndex _ _ = 0
+    summandIndex _ _ _ = 0
 
 
 instance SummandIndex (Found p) f g => SummandIndex (Found (Le p)) f (g :+: g') where
-    summandIndex _ x = summandIndex (P :: Proxy (Found p)) x
+    summandIndex _ _ x = summandIndex (P :: Proxy g) (P :: Proxy (Found p)) x
 
 
-instance SummandIndex (Found p) f g => SummandIndex (Found (Ri p)) f (g' :+: g) where
-    summandIndex _ x = summandSize (P :: Proxy g) + summandIndex (P :: Proxy (Found p)) x
+instance (SummandIndex (Found p) f g', KnownNat (SummandSize g)) => SummandIndex (Found (Ri p)) f (g :+: g') where
+    summandIndex _ _ x = summandSize (P :: Proxy g) + summandIndex (P :: Proxy g') (P :: Proxy (Found p)) x
 
 
 instance (SummandIndex (Found p1) f1 g, SummandIndex (Found p2) f2 g)
     => SummandIndex (Found (Sum p1 p2)) (f1 :+: f2) g where
-    summandIndex _ (Inl x) = summandIndex (P :: Proxy (Found p1)) x
-    summandIndex _ (Inr x) = summandIndex (P :: Proxy (Found p2)) x
+    summandIndex _ _ (Inl x) = summandIndex (P :: Proxy g) (P :: Proxy (Found p1)) x
+    summandIndex _ _ (Inr x) = summandIndex (P :: Proxy g) (P :: Proxy (Found p2)) x

--- a/src/Data/Comp/Multi/SummandIndex.hs
+++ b/src/Data/Comp/Multi/SummandIndex.hs
@@ -7,6 +7,16 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Data.Comp.Multi.SummandIndex where
+{-
+Module      : SummandIndex
+Description : Type level calculation of the size of a summand in a higher order compositional functor
+              and a type class to calculate the index of a summand within a higher order compositional functor.
+              This can be used to produce a map from summand index to some value.
+
+This module provides a type level calculation of the size of a summand in a higher order compositional functor.
+It also provides a type class to calculate the index of a summand within a higher order compositional functor.
+You can use this to produce a map from summand index to some value.
+-}
 
 import Data.Kind
 import Data.Comp.Multi.Ops
@@ -15,17 +25,19 @@ import GHC.TypeLits
 import qualified Data.Proxy as P
 
 
+
+-- Type level calculation of the size of a particular summand.
 type family SummandSize (f :: (Type -> Type) -> Type -> Type) where
   SummandSize (f :+: g) = SummandSize f + SummandSize g
   SummandSize _ = 1
 
 
-summandSize :: forall (f :: (Type -> Type) -> Type -> Type) (num :: Type) . (Integral num, KnownNat (SummandSize f)) => (Proxy f) -> num
-summandSize (_pr :: Proxy f) = fromIntegral $ natVal (P :: Proxy (SummandSize f))
+-- Given the size type of the summand create an integer value.
+getSummandSize :: forall (f :: (Type -> Type) -> Type -> Type) (num :: Type) . (Integral num, KnownNat (SummandSize f)) => (Proxy f) -> num
+getSummandSize (_pr :: Proxy f) = fromIntegral $ natVal (P :: Proxy (SummandSize f))
 
-getSummandIndex :: forall f g a i . (f :<: g, SummandIndex (ComprEmb (Elem f g)) f g) => P.Proxy g -> f a i -> Int
-getSummandIndex _pr = summandIndex (P :: Proxy g) (P :: Proxy (ComprEmb (Elem f g)))
 
+-- | Given a higher order compositional functor g and a summand f return a unique index for the summand f within g.
 class SummandIndex p (f :: (Type -> Type) -> Type -> Type) (g :: (Type -> Type) -> Type -> Type) where
     summandIndex :: Proxy g -> Proxy p -> f a i -> Int
 
@@ -39,7 +51,7 @@ instance SummandIndex (Found p) f g => SummandIndex (Found (Le p)) f (g :+: g') 
 
 
 instance (SummandIndex (Found p) f g', KnownNat (SummandSize g)) => SummandIndex (Found (Ri p)) f (g :+: g') where
-    summandIndex _ _ x = summandSize (P :: Proxy g) + summandIndex (P :: Proxy g') (P :: Proxy (Found p)) x
+    summandIndex _ _ x = getSummandSize (P :: Proxy g) + summandIndex (P :: Proxy g') (P :: Proxy (Found p)) x
 
 
 instance (SummandIndex (Found p1) f1 g, SummandIndex (Found p2) f2 g)
@@ -47,3 +59,7 @@ instance (SummandIndex (Found p1) f1 g, SummandIndex (Found p2) f2 g)
     summandIndex _ _ (Inl x) = summandIndex (P :: Proxy g) (P :: Proxy (Found p1)) x
     summandIndex _ _ (Inr x) = summandIndex (P :: Proxy g) (P :: Proxy (Found p2)) x
 
+
+-- | Given a higher order compositional functor g and a summand f return a unique index for the summand f within g.
+getSummandIndex :: forall f g a i . (f :<: g, SummandIndex (ComprEmb (Elem f g)) f g) => P.Proxy g -> f a i -> Int
+getSummandIndex _pr = summandIndex (P :: Proxy g) (P :: Proxy (ComprEmb (Elem f g)))

--- a/src/Data/Comp/Multi/SummandIndex.hs
+++ b/src/Data/Comp/Multi/SummandIndex.hs
@@ -20,8 +20,10 @@ type family SummandSize (f :: (Type -> Type) -> Type -> Type) where
 
 
 summandSize :: forall (f :: (Type -> Type) -> Type -> Type) (num :: Type) . (Integral num, KnownNat (SummandSize f)) => (Proxy f) -> num
-summandSize (pr :: Proxy f) = fromIntegral $ natVal (P :: Proxy (SummandSize f))
+summandSize (_pr :: Proxy f) = fromIntegral $ natVal (P :: Proxy (SummandSize f))
 
+getSummandIndex :: forall f g a i . (f :<: g, SummandIndex (ComprEmb (Elem f g)) f g) => Proxy g -> f a i -> Int
+getSummandIndex pr = summandIndex pr (P :: Proxy (ComprEmb (Elem f g)))
 
 class SummandIndex p (f :: (Type -> Type) -> Type -> Type) (g :: (Type -> Type) -> Type -> Type) where
     summandIndex :: Proxy g -> Proxy p -> f a i -> Int
@@ -43,3 +45,4 @@ instance (SummandIndex (Found p1) f1 g, SummandIndex (Found p2) f2 g)
     => SummandIndex (Found (Sum p1 p2)) (f1 :+: f2) g where
     summandIndex _ _ (Inl x) = summandIndex (P :: Proxy g) (P :: Proxy (Found p1)) x
     summandIndex _ _ (Inr x) = summandIndex (P :: Proxy g) (P :: Proxy (Found p2)) x
+

--- a/src/Data/Comp/Multi/SummandIndex.hs
+++ b/src/Data/Comp/Multi/SummandIndex.hs
@@ -12,6 +12,7 @@ import Data.Kind
 import Data.Comp.Multi.Ops
 import Data.Comp.SubsumeCommon
 import GHC.TypeLits
+import qualified Data.Proxy as P
 
 
 type family SummandSize (f :: (Type -> Type) -> Type -> Type) where
@@ -22,8 +23,8 @@ type family SummandSize (f :: (Type -> Type) -> Type -> Type) where
 summandSize :: forall (f :: (Type -> Type) -> Type -> Type) (num :: Type) . (Integral num, KnownNat (SummandSize f)) => (Proxy f) -> num
 summandSize (_pr :: Proxy f) = fromIntegral $ natVal (P :: Proxy (SummandSize f))
 
-getSummandIndex :: forall f g a i . (f :<: g, SummandIndex (ComprEmb (Elem f g)) f g) => Proxy g -> f a i -> Int
-getSummandIndex pr = summandIndex pr (P :: Proxy (ComprEmb (Elem f g)))
+getSummandIndex :: forall f g a i . (f :<: g, SummandIndex (ComprEmb (Elem f g)) f g) => P.Proxy g -> f a i -> Int
+getSummandIndex _pr = summandIndex (P :: Proxy g) (P :: Proxy (ComprEmb (Elem f g)))
 
 class SummandIndex p (f :: (Type -> Type) -> Type -> Type) (g :: (Type -> Type) -> Type -> Type) where
     summandIndex :: Proxy g -> Proxy p -> f a i -> Int


### PR DESCRIPTION
This adds a SummandIndex typeclass that allows you to derive a unique index for a summand in the context of a larger compositional datatype.